### PR TITLE
Identify overlapping PAMs with generate function 

### DIFF
--- a/crispio/map.py
+++ b/crispio/map.py
@@ -467,7 +467,7 @@ class GuideLibrary:
             _pam_search = (reverse_complement(pam_search) if reverse 
                            else pam_search)
 
-            with tqdm(find_iupac(_pam_search, genome)) as t:  ## run a progress bar
+            with tqdm(find_iupac(_pam_search, genome, overlapped = True)) as t:  ## run a progress bar
                 
                 for (pam_start, pam_end), pam_seq in t:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
   "carabiner-tools>=0.0.4",
   "pyyaml",
   "nemony",
-  "streq",
+  "streq>=0.0.3",
   "tqdm",
 ]
 


### PR DESCRIPTION
Fixes issue #5. 

Problem: Generate function currently only identifies non-overlapping PAM sites. This behaviour is part of the find_iupac function, from the streq package.

This commit updates in tandem with streq/slparkhill-patch-1, which uses the regex package to add the option to identify overlapping PAM sites (thus designing all possible guides). This option is enabled for the generate function only in this patch - not yet tested where find_iupac used in other functions. Default behaviour of streq patch is to not identify overlapping sequences, so shouldn't change behaviour where find_iupac used elsewhere.

Tested as part of crispio generate, and behaves as expected.